### PR TITLE
:memo: 增加用docker部署并使用SQLite数据库时的注意事项

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ docker pull b3log/pipe
   docker run --detach --name pipe --volume ~/pipe.db:/opt/pipe/pipe.db --publish 5897:5897 \
       b3log/pipe --sqlite="/opt/pipe/pipe.db" --runtime_mode=prod --port=5897 --server=http://localhost:5897
   ```
+  注意：需先确保SQLite数据库文件已存在。如果数据库文件不存在时，docker run --volume参数默认将宿主路径识别为目录，并自动创建这个目录，这可能导致pipe创建sqlite数据库文件失败。新建数据库文件可以简单用touch命令，如：
+  ```shell
+  $ touch ~/pipe.db
+  ```
 
 启动参数说明：
 

--- a/README_en_US.md
+++ b/README_en_US.md
@@ -103,6 +103,10 @@ docker pull b3log/pipe
   docker run --detach --name pipe --volume ~/pipe.db:/opt/pipe/pipe.db --publish 5897:5897 \
       b3log/pipe --sqlite="/opt/pipe/pipe.db" --runtime_mode=prod --port=5897 --server=http://localhost:5897
   ```
+  NOTE：You should confirm the sqlite db file has existed. If the sqlite db file is not existed, the --volume option of docker run command will recognize the host path as a directory, and create it. That may cause pipe to fail to create the sqlite db file. Make sure the new sqlite db file existed, you can use the touch command simply, just like:
+  ```shell
+  $ touch ~/pipe.db
+  ```
 
 Start command line arguments description:
 


### PR DESCRIPTION
补充dockers部署使用SQLite数据库说明。
```shell
docker run --detach --name pipe --volume ~/pipe.db:/opt/pipe/pipe.db --publish 5897:5897 \
    b3log/pipe --sqlite="/opt/pipe/pipe.db" --runtime_mode=prod --port=5897 --server=http://localhost:5897
```
docker run的--volume选项默认宿主路径是目录，并且路径不存在时会自动创建这个目录。在使用SQLite数据库部署的这个docker指令中，如果宿主~/pipe.db文件不存在，docker run会自动创建pipe.db目录，这会导致pipe创建sqlite数据库报错：
```shell
D 2023/02/05 17:47:17 confs.go:127: ${home} [/root]
D 2023/02/05 17:47:17 confs.go:145: ${time} [1675590437932523752]
D 2023/02/05 17:47:17 confs.go:188: configurations [&model.Configuration{Server:"http://localhost:5897", StaticServer:"http://localhost:5897", StaticResourceVersion:"1642481368147", LogLevel:"debug", ShowSQL:false, SessionSecret:"26m7j0hfjyx50bta0s7sp7ngf95cepmp", SessionMaxAge:86400, RuntimeMode:"prod", SQLite:"/opt/pipe/pipe.db", MySQL:"", Postgres:"", Port:"5897", AxiosBaseURL:"/api", MockServer:"http://localhost:8888"}]
D 2023/02/05 17:47:17 themes.go:43: loaded [7] themes
F 2023/02/05 17:47:17 db.go:51: opens database failed: unable to open database file: is a directory
```