### PR TITLE
fix: correct fialed to failed typo in i18n logger message

### DIFF
--- a/i18n/locales.go
+++ b/i18n/locales.go
@@ -54,7 +54,7 @@ func Load() {
 func load(localeStr string) {
 	bytes, err := ioutil.ReadFile("i18n/" + localeStr + ".json")
 	if nil != err {
-		logger.Fatal("reads i18n configurations fialed: " + err.Error())
+		logger.Fatal("reads i18n configurations failed: " + err.Error())
 	}
 
 	l := locale{Name: localeStr}


### PR DESCRIPTION
## Summary
Corrects `fialed` → `failed` typo in `i18n/locales.go:57` logger message.

## Change
- File: `i18n/locales.go`
- Line 57: `logger.Fatal("reads i18n configurations fialed: " + err.Error())`
- Fix: `fialed` → `failed`

## Testing
- `go build ./...`
- Only 1 file changed, 1 line modified